### PR TITLE
Improve Windows compatibility

### DIFF
--- a/clevr_ltn_rule.py
+++ b/clevr_ltn_rule.py
@@ -1,9 +1,14 @@
 import json
+import os
 import torch
 import ltn
 
-# Load CLEVR validation scenes
-with open("/Users/kargichauhan/Documents/Work/LTN/CLEVR_v1.0/scenes/CLEVR_val_scenes.json", "r") as f:
+# Load CLEVR validation scenes. The CLEVR dataset location can be provided via
+# the CLEVR_DIR environment variable. By default we look for a local
+# ``CLEVR_v1.0`` directory.
+clevr_dir = os.getenv("CLEVR_DIR", "CLEVR_v1.0")
+scenes_path = os.path.join(clevr_dir, "scenes", "CLEVR_val_scenes.json")
+with open(scenes_path, "r") as f:
     data = json.load(f)
 
 class RubberModelLearnable(torch.nn.Module):

--- a/evaluate_rules.py
+++ b/evaluate_rules.py
@@ -264,8 +264,9 @@ def evaluate_rules(rules_file: str, clevr_dir: str, output_dir: str):
         print("- Baseline comparison: ")
 
 if __name__ == "__main__":
+    clevr_dir = os.getenv("CLEVR_DIR", "CLEVR_v1.0")
     evaluate_rules(
         rules_file="rule_analysis.json",
-        clevr_dir="/Users/kargichauhan/Documents/Work/LTN/CLEVR_v1.0",
+        clevr_dir=clevr_dir,
         output_dir="evaluation_results"
     )

--- a/export_groundings.py
+++ b/export_groundings.py
@@ -17,9 +17,12 @@ from models.shape_net import ShapeNet
 from data_utils_clevr import load_clevr_scenes, extract_object_data_for_scene
 
 # ─── Configuration ──────────────────────────────────────────────────────────
-MODEL_DIR   = "models/"
-SCENES_JSON = "CLEVR_v1.0/scenes/CLEVR_val_scenes.json"
-OUT_DIR     = "data/groundings/"
+MODEL_DIR = "models/"
+# Allow overriding the CLEVR dataset path via the CLEVR_DIR environment
+# variable. This makes the script portable across operating systems.
+CLEVR_DIR = os.getenv("CLEVR_DIR", "CLEVR_v1.0")
+SCENES_JSON = os.path.join(CLEVR_DIR, "scenes", "CLEVR_val_scenes.json")
+OUT_DIR = "data/groundings/"
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # ─── Load trained predicate networks ────────────────────────────────────────

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -11,13 +11,13 @@ def get_project_root() -> Path:
     """Get the absolute path to the project root"""
     return Path(__file__).parent.absolute()
 
-def run_command(command: str, cwd: str = None) -> None:
-    """Run a command and print its output"""
-    print(f"\n=== Running: {command} ===")
+def run_command(command: list[str], cwd: str | None = None) -> None:
+    """Run a command list and print its output"""
+    print(f"\n=== Running: {' '.join(command)} ===")
     try:
         result = subprocess.run(
             command,
-            shell=True,
+            shell=False,
             capture_output=True,
             text=True,
             cwd=cwd
@@ -56,31 +56,31 @@ def main():
     
     # 1. Data Validation
     print("\n=== Step 1: Data Validation ===")
-    run_command("python3 validate_groundings.py", cwd=str(root))
+    run_command([sys.executable, "validate_groundings.py"], cwd=str(root))
     
     # 2. Rule Synthesis
     print("\n=== Step 2: Rule Synthesis ===")
-    run_command("python3 synthesize_rules.py", cwd=str(root))
+    run_command([sys.executable, "synthesize_rules.py"], cwd=str(root))
     
     # 3. Rule Verification
     print("\n=== Step 3: Rule Verification ===")
-    run_command("python3 verify_rule_consistency.py", cwd=str(root))
+    run_command([sys.executable, "verify_rule_consistency.py"], cwd=str(root))
     
     # 4. Rule Analysis
     print("\n=== Step 4: Rule Analysis ===")
-    run_command("python3 analyze_rules.py", cwd=str(root))
+    run_command([sys.executable, "analyze_rules.py"], cwd=str(root))
     
     # 5. Visualization
     print("\n=== Step 5: Visualization ===")
-    run_command("python3 visualize_rules.py", cwd=str(root))
+    run_command([sys.executable, "visualize_rules.py"], cwd=str(root))
     
     # 6. Evaluation
     print("\n=== Step 6: Evaluation ===")
-    run_command("python3 evaluate_rules.py", cwd=str(root))
+    run_command([sys.executable, "evaluate_rules.py"], cwd=str(root))
     
     # 7. Results Summary
     print("\n=== Step 7: Results Summary ===")
-    run_command("python3 summarize_results.py", cwd=str(root))
+    run_command([sys.executable, "summarize_results.py"], cwd=str(root))
     
     print("\n=== Pipeline Complete ===")
     print("Results are available in the following directories:")

--- a/visualize_rules.py
+++ b/visualize_rules.py
@@ -173,9 +173,10 @@ def create_visualizations(rules_file: str, verification_file: str, clevr_dir: st
             print(f"Counterexample visualization saved to: {output_path}")
 
 if __name__ == "__main__":
+    clevr_dir = os.getenv("CLEVR_DIR", "CLEVR_v1.0")
     create_visualizations(
         rules_file="synthesized_rules.json",
         verification_file="rule_verification_results.json",
-        clevr_dir="/Users/kargichauhan/Documents/Work/LTN/CLEVR_v1.0",
+        clevr_dir=clevr_dir,
         output_dir="visualizations"
     )


### PR DESCRIPTION
## Summary
- make export_groundings respect `CLEVR_DIR`
- parameterize dataset path in `evaluate_rules`, `visualize_rules` and `clevr_ltn_rule`
- run Python pipeline commands via the current interpreter

## Testing
- `python3 -m py_compile run_pipeline.py`
- `python3 -m py_compile evaluate_rules.py`
- `python3 -m py_compile visualize_rules.py`
- `python3 -m py_compile export_groundings.py`
- `python3 -m py_compile clevr_ltn_rule.py`
- `python3 test_print.py`


------
https://chatgpt.com/codex/tasks/task_e_6881b6f5dd708333b0b2736532b3227b